### PR TITLE
:green_heart: (ci) allow upgrade action to manage labels

### DIFF
--- a/.github/workflows/trunk-upgrade.yml
+++ b/.github/workflows/trunk-upgrade.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write # ✅ needed to create/edit labels
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
add issues: write permission to nightly Trunk upgrade workflow to allow label
creation/updates during PR automation