### PR TITLE
:construction_worker: (github-actions) emulator matrix + nightly guard nly

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: ["**"]
+  schedule:
+    - cron: 0 2 * * * # Nightly at 02:00 UTC
   workflow_dispatch:
 
 concurrency:
@@ -15,6 +17,49 @@ permissions:
   contents: read
 
 jobs:
+  nightly-change-check:
+    name: Nightly Change Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Prepare cache dir
+        run: mkdir -p .github/.nightly_cache
+
+      - name: Restore last nightly commit
+        id: restore
+        uses: actions/cache/restore@v4
+        with:
+          path: .github/.nightly_cache
+          key: nightly-sha-
+          restore-keys: |
+            nightly-sha-
+
+      - name: Check if commit changed
+        id: check
+        run: |
+          CURRENT_SHA="${GITHUB_SHA}"
+          LAST_FILE=".github/.nightly_cache/last_sha"
+          if [ -f "$LAST_FILE" ]; then LAST_SHA=$(cat "$LAST_FILE"); else LAST_SHA=""; fi
+          if [ "$CURRENT_SHA" = "$LAST_SHA" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo -n "$CURRENT_SHA" > "$LAST_FILE"
+          fi
+
+      - name: Save new nightly commit
+        if: steps.check.outputs.changed == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .github/.nightly_cache
+          key: nightly-sha-${{ github.sha }}
   detekt-paths:
     name: Detect Detekt-relevant changes
     runs-on: ubuntu-latest
@@ -178,6 +223,62 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 30
+          arch: x86_64
+          target: google_apis
+          profile: pixel_6
+          emulator-options: -no-snapshot -no-window -gpu swiftshader_indirect -no-boot-anim -camera-back none -noaudio
+          disable-animations: false
+          script: ./gradlew --no-daemon --stacktrace :app:connectedDebugAndroidTest
+
+      - name: Upload androidTest reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumentation-test-reports
+          path: |
+            app/build/outputs/androidTest-results/**
+            app/build/reports/androidTests/connected/**
+
+  instrumentation-tests-matrix:
+    name: Instrumentation Tests (Emulator - Full Matrix)
+    runs-on: ubuntu-latest
+    needs: [nightly-change-check]
+    if: github.event_name == 'schedule' && needs.nightly-change-check.outputs.changed == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        api-level: [29, 30, 33]
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Cache AVD (API ${{ matrix.api-level }})
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.android/avd
+            ~/.android/adb
+          key: avd-${{ runner.os }}-api${{ matrix.api-level }}-google_apis-x86_64-v1
+          restore-keys: |
+            avd-${{ runner.os }}-
+
+      - name: Pre-build app and androidTest APKs
+        run: ./gradlew --no-daemon --stacktrace :app:assembleDebug :app:assembleAndroidTest
+
+      - name: Run emulator and connected tests (API ${{ matrix.api-level }})
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
           arch: x86_64
           target: google_apis
           profile: pixel_6


### PR DESCRIPTION
nly

add nightly schedule at 02:00 UTC
add nightly-change-check job to skip redundant nightlies by caching last HEAD sha
add full emulator matrix job (API 29, 30, 33) for push/schedule, gated by change check
keep PR pipeline fast: unit, lint, single emulator only