### PR TITLE
:pencil: (docs) add ci and development docs

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,4 +1,13 @@
 name: Android CI
+# Pipeline summary:
+# - Triggers: push (main), pull_request (all branches), manual, and nightly schedule (02:00 UTC)
+# - Path gating: `detekt-paths` uses `dorny/paths-filter` to decide whether tests/lint/detekt should run
+# - Unit tests: build + test with Kover coverage, artifact reports uploaded
+# - Lint: Android Lint, artifact report uploaded
+# - Detekt: runs on push/PR only when Kotlin/Gradle paths changed; artifact uploaded
+# - Instrumentation tests: disabled on push/PR (Linux emulator instability; macOS cost). To enable, gate with
+#   `needs.detekt-paths.outputs.tests_should_run == 'true' && (github.event_name == 'pull_request' || github.event_name == 'push')`
+# - Nightly: change-check job prevents redundant nightly runs; optional full emulator matrix (API 29/30/33)
 
 on:
   push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,26 @@ We run Trunk in CI using official actions. See `.github/workflows/`:
 
 - `trunk.yml`: Runs on push and pull_request, posts annotations on failures.
 - `trunk-upgrade.yml`: Nightly job that opens a PR to upgrade Trunk linters/tools.
+- `android-ci.yml`: Android CI with unit tests (Kover coverage), Android Lint, Detekt (push/PR; path-gated via `dorny/paths-filter`), instrumentation tests disabled on PR/push (Linux emulator instability; macOS minutes cost). Nightly runs include a change-check gate and an optional full emulator matrix (API 29/30/33) that runs only on schedule when the last commit changed.
 
 No extra secrets are required; the default `GITHUB_TOKEN` is sufficient for annotations and upgrade PRs.
+
+## Dependabot
+
+- Location: `.github/dependabot.yml`
+- Gradle updates:
+  - Schedule: weekly, Monday, 09:00 UTC
+  - Open PR limit: 5
+  - Reviewers/assignees: `inventrohyder`
+  - Labels: `dependencies`, `gradle`
+  - Commit message: prefix `:arrow_up:` with scope
+  - Groups: `androidx`, `compose`, `firebase`, `google-services`, `kotlin` (minor/patch grouped)
+  - Ignored majors: `androidx.compose:compose-bom`, `com.google.firebase:firebase-bom`
+- GitHub Actions updates:
+  - Schedule: weekly, Monday, 09:00 UTC
+  - Open PR limit: 3
+  - Reviewers/assignees: `inventrohyder`
+  - Labels: `dependencies`, `github-actions`
 
 ## Upgrading Trunk, linters, and runtimes
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,34 @@
+# Development Guide
+
+## Local Tooling
+
+- Trunk CLI manages linters, formatters, and hooks
+  - Install/upgrade: `./.trunk/tools/trunk upgrade -y`
+  - Format: `./.trunk/tools/trunk fmt`
+  - Check: `./.trunk/tools/trunk check`
+  - See [LINTING.md](LINTING.md) for comprehensive linting guide
+
+- Commitizen (Gitmoji) for commits
+  - Run `gt create` or `gt modify` and follow the prompts
+  - Emoji-first format is validated by `commitlint.config.js`
+
+## Running Locally
+
+- Build debug: `./gradlew :app:assembleDebug`
+- Unit tests: `./gradlew :app:testDebugUnitTest`
+- Lint: `./gradlew :app:lintDebug`
+- Detekt: `./gradlew :app:detekt` (code quality analysis, non-blocking in CI)
+- Coverage (unit tests): `./gradlew :app:koverXmlReport :app:koverHtmlReport`
+- Instrumentation tests: `./gradlew :app:connectedDebugAndroidTest` (needs emulator/device)
+
+## CI Expectations
+
+- PRs must pass: unit tests, Android Lint, and emulator smoke (API 30)
+- Post-merge to main also runs Detekt and the full emulator matrix (API 29/30/33)
+- Nightly at 02:00 UTC re-runs matrix only if the main HEAD changed since the last nightly
+
+## Troubleshooting
+
+- Formatter/CI disagreement (e.g., YAML quoting): prefer unquoted cron values; comments explain schedules
+- Slow emulator boot in CI: ensure AVD cache keys match API/arch/target
+- Trunk hook issues: `./.trunk/tools/trunk git-hooks sync`

--- a/docs/LINTING.md
+++ b/docs/LINTING.md
@@ -1,0 +1,184 @@
+# Linting & Formatting Guide
+
+## Current Approach
+
+### ktlint (via Trunk) - Formatting
+
+- **Purpose**: All code formatting using standard Kotlin conventions
+- **When it runs**: On file save, pre-commit hooks, `.trunk/tools/trunk fmt`
+- **What it checks**: Kotlin formatting (120 chars, explicit imports, indentation)
+- **Speed**: Very fast (~seconds)
+
+### detekt (via Gradle) - Analysis Only
+
+- **Purpose**: Code quality analysis (formatting disabled)
+- **When it runs**: During builds, CI pipeline, manual runs
+- **What it checks**:
+  - Code complexity and maintainability
+  - Potential bugs and code smells
+  - Performance issues
+  - Naming conventions
+- **Speed**: Slower (~10-30 seconds) but comprehensive
+
+## Why This Setup?
+
+**Originally**, we wanted to use detekt's formatting (which wraps ktlint) for a unified toolchain. However, we encountered a version conflict:
+
+- Trunk uses ktlint 1.7.1 (latest)
+- Detekt 1.23.8 bundles ktlint 0.50.0 (older)
+
+These versions have **incompatible indentation rules** that caused ping-ponging formatting conflicts. After 11+ months waiting for detekt to update to ktlint 1.x, we disabled detekt formatting to resolve the conflict.
+
+**Benefits of current approach**:
+
+- No formatting conflicts
+- Uses latest ktlint standards
+- Clear separation of concerns
+- Still get comprehensive code quality analysis from detekt
+
+## Configuration Decisions
+
+### Disabled Rules & Reasoning
+
+We've disabled certain detekt rules that don't align with modern Android/Compose development:
+
+#### **MagicNumber** (disabled)
+
+```yaml
+MagicNumber:
+  active: false # Android UI uses many numeric constants
+```
+
+**Why**: Android UI code has many legitimate constants (16.dp, 8.dp, animation durations, etc.)
+
+#### **WildcardImport** (disabled)
+
+```yaml
+WildcardImport:
+  active: false # Kotlin style guide allows wildcards for common packages
+```
+
+**Why**: Kotlin style guide permits wildcards for common packages like `kotlinx.*` and `androidx.compose.*`
+
+#### **LongMethod** (disabled)
+
+```yaml
+LongMethod:
+  active: false # Compose UI functions can be naturally long
+```
+
+**Why**: Compose UI functions are declarative and can legitimately be long without being complex
+
+#### **LongParameterList** (disabled)
+
+```yaml
+LongParameterList:
+  active: false # Compose functions often need many parameters
+```
+
+**Why**: Compose functions often require many parameters for customization and state management
+
+#### **FunctionNaming** (disabled)
+
+```yaml
+FunctionNaming:
+  active: false # Conflicts with @Composable PascalCase convention
+```
+
+**Why**: `@Composable` functions use PascalCase (e.g., `LoginScreen()`) which conflicts with camelCase rule
+
+#### **MatchingDeclarationName** (disabled)
+
+```yaml
+MatchingDeclarationName:
+  active: false # Android allows naming flexibility
+```
+
+**Why**: Android conventions allow flexibility (e.g., `MainActivity` class in `MainActivity.kt`)
+
+### Standard Kotlin Conventions
+
+We follow ktlint's defaults:
+
+- **120 character lines**: Standard Kotlin convention
+- **Explicit imports**: Clear dependency visibility (no wildcards)
+- **4-space indentation**: Standard for Kotlin code
+
+## Commands & Usage
+
+### Quick Development Workflow
+
+```bash
+# Format files (fast)
+.trunk/tools/trunk fmt
+
+# Quick lint check (fast)
+.trunk/tools/trunk check
+
+# Check specific files
+.trunk/tools/trunk check app/src/main/java/com/test/testing/MainActivity.kt
+```
+
+### Code Quality Analysis
+
+```bash
+# Full detekt analysis (no formatting)
+./gradlew detekt
+
+# Generate detekt reports
+./gradlew detekt
+# Reports: app/build/reports/detekt/
+```
+
+### CI/CD Integration
+
+Our CI pipeline runs:
+
+1. **Fast checks** (ktlint via Trunk) - blocking
+2. **Comprehensive analysis** (detekt) - non-blocking but monitored
+
+## Troubleshooting
+
+### Common Issues
+
+#### "Formatting conflict between ktlint and detekt"
+
+- **Cause**: Version mismatch (trunk ktlint 1.7.1 vs detekt ktlint 0.50.0)
+- **Solution**: Disabled detekt formatting, use only ktlint via Trunk
+
+#### "detekt takes too long"
+
+- **Cause**: Running detekt on every small change
+- **Solution**: Use `.trunk/tools/trunk fmt` for quick fixes, detekt for thorough checks
+
+#### "IDE formatting differs from ktlint"
+
+- **Cause**: IDE settings not matching ktlint defaults
+- **Solution**: Configure your IDE to use 120-char lines and explicit imports, or just rely on ktlint via Trunk to format on save
+
+### Getting Help
+
+1. Check this documentation first
+2. Run `.trunk/tools/trunk --help` for Trunk commands
+3. Run `./gradlew detekt --help` for detekt options
+4. For rule-specific questions, see [detekt documentation](https://detekt.dev)
+
+## Best Practices
+
+### For Developers
+
+- Run `.trunk/tools/trunk fmt` before committing
+- Fix any ktlint issues immediately (they're quick)
+- Review detekt reports weekly for code quality insights
+
+### For Code Reviews
+
+- ktlint violations should be auto-fixed, not discussed
+- Focus code review discussions on detekt findings
+- Use detekt reports to identify refactoring opportunities
+
+### For CI/CD
+
+- ktlint violations block merges (fast feedback)
+- detekt issues are informational but should be addressed
+- Track detekt metrics over time for code quality trends

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,70 @@
+# Android CI and Quality Gates
+
+This document explains our GitHub Actions CI, what runs on each event, and how to reproduce locally.
+
+## Overview
+
+We use a single workflow at `.github/workflows/android-ci.yml` with distinct jobs:
+
+- Build and Unit Tests (with Kover coverage) — path-gated
+- Android Lint — path-gated
+- Detekt — path-gated; runs on PR and push
+- Instrumentation Tests (PR smoke, API 30, with AVD cache) — path-gated
+- Instrumentation Tests Matrix (nightly only: API 29/30/33) + manual dispatch
+- Nightly Change Guard (skips nightly matrix runs if the main HEAD hasn’t changed since the previous run)
+
+Java 17 is used (AGP 8.x requirement). Gradle caching is handled by `gradle/actions/setup-gradle@v4`.
+
+## Events and Triggers
+
+- pull_request (any branch):
+  - Path-gated Build + Unit Tests (Kover html/xml reports uploaded)
+  - Path-gated Android Lint (HTML report uploaded)
+  - Path-gated Instrumentation Tests (API 30 smoke, AVD cache)
+  - Path-gated Detekt
+- push (to `main` only):
+  - Same as PR (path-gated)
+- schedule (Nightly at 02:00 UTC):
+  - Nightly Change Guard checks last recorded sha; matrix runs only if HEAD changed
+  - Instrumentation Tests Matrix (API 29/30/33)
+- workflow_dispatch:
+  - Manually trigger full matrix as needed
+- schedule (Nightly at 02:00 UTC):
+  - Nightly Change Guard checks last recorded sha; matrix runs only if HEAD changed
+
+## Cost and Speed Optimizations
+
+- Single-API emulator smoke (PRs) keeps checks fast and budget-friendly
+- Full emulator matrix runs only on push/nightly
+- Detekt is push-only and path-gated by `dorny/paths-filter` (skips docs/markdown-only changes)
+- AVD cache (API-specific keys) speeds up emulator start
+- Gradle wrapper validation is provided by `setup-gradle@v4`
+
+## Artifacts
+
+- Unit test reports: `app/build/test-results/testDebugUnitTest/**`, `app/build/reports/tests/testDebugUnitTest/**`
+- Coverage: `app/build/reports/kover/html/**`, `app/build/reports/kover/xml/**`
+- Lint: `app/build/reports/lint-results-debug.html`
+- Instrumentation tests: `app/build/outputs/androidTest-results/**`, `app/build/reports/androidTests/connected/**`
+
+## Local Reproduction
+
+- Unit tests: `./gradlew :app:testDebugUnitTest`
+- Build app: `./gradlew :app:assembleDebug`
+- Lint: `./gradlew :app:lintDebug`
+- Detekt (non-blocking in CI): `./gradlew :app:detekt`
+- Coverage (unit tests): `./gradlew :app:koverXmlReport :app:koverHtmlReport`
+- Instrumentation tests (requires device/emulator): `./gradlew :app:connectedDebugAndroidTest`
+
+## Nightly Change Guard Details
+
+- Restores cached `.github/.nightly_cache/last_sha` via `actions/cache/restore@v4`
+- Compares current `GITHUB_SHA` to `last_sha`
+- If unchanged, matrix job is skipped
+- If changed, updates `last_sha` and saves cache via `actions/cache/save@v4`
+
+## Future Enhancements (Optional)
+
+- Codecov upload (Kover XML) once org approval exists; add `codecov.yml` with informational thresholds
+- Coverage thresholds for PR gating (unit only or combined)
+- Additional Detekt rules once the baseline stabilizes


### PR DESCRIPTION
Add docs/ci.md covering PR/push/nightly jobs, artifacts, AVD cache,
path-gated Detekt, and nightly change guard
Add docs/DEVELOPMENT.md with local commands (build, tests, lint, detekt, coverage, instrumentation) and troubleshooting
Update CONTRIBUTING.md to reference android-ci.yml capabilities