### PR TITLE
:wrench: (android) Migrate to Kotlin 2.2; switch firebase ktx; bump deps

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.test.testing"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.test.testing"
@@ -32,11 +32,14 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions {
-        jvmTarget = "11"
-    }
     buildFeatures {
         compose = true
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
 
@@ -50,21 +53,21 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("com.google.maps.android:maps-compose:2.11.4")
-    implementation("com.google.android.gms:play-services-maps:18.2.0")
-    implementation("com.google.android.gms:play-services-location:21.1.0")
-    implementation("com.squareup.retrofit2:retrofit:2.9.0")
-    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
-    implementation("androidx.fragment:fragment-ktx:1.8.3")
+    implementation(libs.androidx.constraintlayout)
+    implementation(libs.maps.compose)
+    implementation(libs.play.services.maps)
+    implementation(libs.play.services.location)
+    implementation(libs.retrofit)
+    implementation(libs.converter.gson)
+    implementation(libs.androidx.fragment.ktx)
 
-    implementation(platform("com.google.firebase:firebase-bom:32.8.0"))
-    implementation("com.google.firebase:firebase-database-ktx")
-    implementation("com.google.firebase:firebase-auth-ktx")
-    implementation("com.google.android.gms:play-services-auth:20.7.0")
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.database)
+    implementation(libs.firebase.auth)
+    implementation(libs.play.services.auth)
 
     // Lifecycle and ViewModel
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2")
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/test/testing/LocShareApp.kt
+++ b/app/src/main/java/com/test/testing/LocShareApp.kt
@@ -2,8 +2,8 @@ package com.test.testing
 
 import android.app.Application
 import android.util.Log
-import com.google.firebase.ktx.Firebase
-import com.google.firebase.ktx.initialize
+import com.google.firebase.Firebase
+import com.google.firebase.initialize
 
 class LocShareApp : Application() {
     private val TAG = "LocShareApp"

--- a/app/src/main/java/com/test/testing/api/FirebaseLocationRepository.kt
+++ b/app/src/main/java/com/test/testing/api/FirebaseLocationRepository.kt
@@ -2,13 +2,13 @@ package com.test.testing.api
 
 import android.location.Location
 import android.util.Log
+import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.ValueEventListener
-import com.google.firebase.database.ktx.database
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.database.database
 
 class FirebaseLocationRepository {
     private val TAG = "FirebaseLocationRepo"

--- a/app/src/main/java/com/test/testing/friends/FriendRepository.kt
+++ b/app/src/main/java/com/test/testing/friends/FriendRepository.kt
@@ -1,12 +1,12 @@
 package com.test.testing.friends
 
 import android.util.Log
+import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
 import com.google.firebase.database.ValueEventListener
-import com.google.firebase.database.ktx.database
-import com.google.firebase.ktx.Firebase
+import com.google.firebase.database.database
 
 /**
  * Repository to manage friend relationships in Firebase

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,6 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.google.gms:google-services:4.4.1")
+        classpath(libs.google.services)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,35 @@
 [versions]
-agp = "8.11.1"
-kotlin = "2.0.21"
-coreKtx = "1.16.0"
+agp = "8.12.0"
+constraintlayout = "2.2.1"
+converterGson = "3.0.0"
+firebaseBom = "34.1.0"
+fragmentKtx = "1.8.9"
+googleServices = "4.4.3"
+kotlin = "2.2.0"
+coreKtx = "1.17.0"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.9.0"
+junitVersion = "1.3.0"
+espressoCore = "3.7.0"
+lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
-composeBom = "2024.09.00"
+composeBom = "2025.08.00"
+lifecycleViewmodelCompose = "2.9.2"
+mapsCompose = "6.7.1"
+playServicesAuth = "21.4.0"
+playServicesLocation = "21.3.0"
+playServicesMaps = "19.2.0"
+retrofit = "3.0.0"
 
 [libraries]
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "fragmentKtx" }
+androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
+converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "converterGson" }
+firebase-auth = { module = "com.google.firebase:firebase-auth" }
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+firebase-database = { module = "com.google.firebase:firebase-database" }
+google-services = { module = "com.google.gms:google-services", version.ref = "googleServices" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -24,6 +43,11 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+maps-compose = { module = "com.google.maps.android:maps-compose", version.ref = "mapsCompose" }
+play-services-auth = { module = "com.google.android.gms:play-services-auth", version.ref = "playServicesAuth" }
+play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocation" }
+play-services-maps = { module = "com.google.android.gms:play-services-maps", version.ref = "playServicesMaps" }
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
- Replace deprecated kotlinOptions { jvmTarget = "11" } with kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_11 } }
  per Kotlin 2.2 guidance: https://kotl.in/u1r8ln
- Upgrade Kotlin to 2.2.0; set compileSdk = 36
- Migrate Firebase dependencies from KTX artifacts to main modules and update imports:
  - com.google.firebase.ktx.Firebase → com.google.firebase.Firebase
  - com.google.firebase.database.ktx.database → com.google.firebase.database.database
  - com.google.firebase.ktx.initialize → com.google.firebase.initialize
  Guidance: https://firebase.google.com/docs/android/kotlin-migration#ktx-apis-to-main-how-to-migrate
- Convert hardcoded dependency strings to Version Catalog aliases; move Google Services classpath to libs alias
- Update dependency versions (examples):
  - Firebase BoM 34.1.0 (and use main modules: firebase-auth, firebase-database)
  - Compose BoM 2025.08.00, lifecycle-viewmodel-compose 2.9.2
  - Maps Compose 6.7.1, Play Services (maps/auth/location), Fragment KTX 1.8.9
  - Retrofit 3.0.0, converter-gson 3.0.0
- Build verified with :app:assembleDebug