### PR TITLE
:arrow_up: (java) update java toolchain to 21 with autodownload

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,36 @@
+/**
+ * Java Configuration
+ * ==================
+ * Toolchain: Java 21 LTS | Build JVM: Varies (17+ required by Gradle 9) | Target: Java 21
+ * Configured: August 2025 (Gradle 9.0 upgrade)
+ *
+ * Definitions:
+ * - Toolchain: JVM used to compile code (Java 21, auto-downloaded if missing)
+ * - Build JVM: JVM running Gradle itself (min Java 17, not project-controlled)
+ * - Target: Bytecode compatibility (Java 21, could be lower if needed)
+ *
+ * Decision rationale:
+ * - Java 21 target: Current LTS (supported until 2029)
+ * - Not Java 22: Non-LTS with only 6 months support
+ * - Toolchain ensures consistent compilation across all developer machines
+ * - Detekt 1.23.8 constraint: Supports JVM targets up to 22
+ * - No desugaring needed: Project uses no Java 8+ APIs (java.time, streams, NIO)
+ *
+ * Note: While Gradle 9 requires Java 17+ to run, the target bytecode could be
+ * as low as Java 8 if needed for older Android devices. We use 21 for modern features.
+ *
+ * Desugaring: Disabled - enable if using java.time/streams/NIO:
+ * compileOptions.isCoreLibraryDesugaringEnabled = true
+ * dependencies { coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4") }
+ *
+ * Upgrade path: Java 25 LTS (Sept 2025) when tooling supports it
+ *
+ * References:
+ * - https://developer.android.com/build/jdks
+ * - https://docs.gradle.org/current/userguide/toolchains.html
+ * - https://detekt.dev/docs/introduction/compatibility/
+ */
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -5,6 +38,12 @@ plugins {
     id("com.google.gms.google-services")
     alias(libs.plugins.kover)
     alias(libs.plugins.detekt)
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 android {
@@ -31,8 +70,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     buildFeatures {
         compose = true
@@ -41,7 +80,7 @@ android {
 
 kotlin {
     compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,5 +21,22 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-# Enable Configuration Cache for better build performance
+
+# Java/JVM Configuration Documentation
+# ====================================
+# Build JVM: Uses system/IDE configured JDK (OpenJDK 24 recommended)
+# Target JVM: Java 21 LTS (configured in app/build.gradle.kts)
+# Desugaring: Not enabled (no Java 8+ API usage detected as of August 2025)
+#
+# To upgrade build JVM:
+# - Install newer JDK and configure in IDE settings
+# - Update JAVA_HOME environment variable if needed
+#
+# To change target JVM:
+# - Update compileOptions and kotlin.compilerOptions in app/build.gradle.kts
+# - Consider enabling desugaring for Java 8+ API features
+
+# Gradle Performance Optimizations
+# =================================
+# Enable Configuration Cache for better build performance (Gradle 9.0+)
 org.gradle.configuration-cache=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,16 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+
+plugins {
+    // Java Toolchain Auto-Provisioning
+    // Enables automatic download of required Java versions when not locally available
+    // Ensures consistent builds across different developer environments
+    // Downloads to Gradle User Home for reuse across projects
+    // Added: August 2025 (Gradle 9.0 upgrade)
+    // Ref: https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
Implement Java toolchain configuration following Android and Gradle best practices
to ensure consistent builds across developer environments.

BREAKING CHANGE: Build now requires Java 17+ to run Gradle 9.0

- Added Java 21 LTS toolchain in `app/build.gradle.kts`
- Updated compilation target from Java 17 to Java 21
- Added Foojay resolver plugin in `settings.gradle.kts` for auto-provisioning

- Fixed Detekt compatibility issue: "Invalid value (24) passed to --jvm-target"
- Detekt 1.23.8 supports max JVM target 22, toolchain ensures Java 21 is used

- **Reproducible builds**: Same Java version across all developer machines
- **Auto-provisioning**: Downloads Java 21 automatically if not locally available
- **Future-proof**: Java 21 LTS supported until 2029
- **Tool compatibility**: All build tasks use consistent Java version

- Java 21 is current LTS (long-term support until 2029)
- Java 22+ are non-LTS with only 6 months support
- Within Detekt 1.23.8 compatibility range (max JVM target 22)

- **Toolchain**: Java 21 (compiles code, auto-downloaded if missing)
- **Build JVM**: Developer's local JVM (min Java 17, runs Gradle)
- **Target**: Java 21 (bytecode compatibility level)

- **Existing developers**: No action needed, toolchain auto-downloads Java 21
- **New developers**: Need Java 17+ to run Gradle 9, toolchain handles compilation
- **CI/CD**: Should work without changes due to auto-provisioning