### PR TITLE
:construction_worker: (ci) report Android Lint, and detekt using Sarif

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -135,6 +135,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detekt-paths]
     if: needs.detekt-paths.outputs.tests_should_run == 'true'
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -151,6 +154,14 @@ jobs:
       - name: Run lint
         run: ./gradlew --no-daemon --stacktrace :app:lintDebug
 
+      - name: Upload Android Lint SARIF to GitHub Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: app/build/reports/lint-results-debug.sarif
+          category: android-lint
+          wait-for-processing: true
+
       - name: Upload lint report
         if: always()
         uses: actions/upload-artifact@v4
@@ -163,6 +174,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detekt-paths]
     if: (github.event_name == 'push' || github.event_name == 'pull_request') && needs.detekt-paths.outputs.detekt_should_run == 'true'
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -178,6 +192,14 @@ jobs:
 
       - name: Run detekt
         run: ./gradlew --no-daemon --stacktrace :app:detekt
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: app/build/reports/detekt/detekt.sarif
+          category: detekt
+          wait-for-processing: true
 
       - name: Upload Detekt report
         if: always()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,12 @@ android {
     buildFeatures {
         compose = true
     }
+    lint {
+        abortOnError = false
+        xmlReport = false
+        htmlReport = true
+        sarifReport = true
+    }
 }
 
 kotlin {
@@ -150,7 +156,7 @@ detekt {
 // Ensure CI artifact uploads have reports available
 tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
     reports {
-        xml.required.set(true)
+        xml.required.set(false)
         html.required.set(true)
         sarif.required.set(true) // enables trunk to catch detekt issues when running trunk check
         txt.required.set(false)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,7 +106,6 @@ dependencies {
     implementation(libs.play.services.location)
     implementation(libs.retrofit)
     implementation(libs.converter.gson)
-    implementation(libs.androidx.fragment.ktx)
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.database)


### PR DESCRIPTION
- CI: upload :app:lintDebug SARIF via code scanning in .github/workflows/android-ci.yml (with security-events: write)
- Build: enable Android Lint sarifReport; keep HTML; disable XML; set abortOnError=false in app/build.gradle.kts
- Detekt: keep SARIF generation; disable XML report