### PR TITLE
:green_heart: (dependabot) avoid assigning the same assignee and reviewer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
     open-pull-requests-limit: 5
     reviewers:
       - inventrohyder
-    assignees:
-      - inventrohyder
     commit-message:
       prefix: ":arrow_up:"
       include: scope
@@ -70,8 +68,6 @@ updates:
       timezone: UTC
     open-pull-requests-limit: 3
     reviewers:
-      - inventrohyder
-    assignees:
       - inventrohyder
     commit-message:
       prefix: ":arrow_up:"


### PR DESCRIPTION
make inventrohyder only a reviewer, not a reviewer and assignee