### PR TITLE
:sparkles: (auth) add Discord system fe…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("boolean", "USE_DISCORD_SYSTEM", "false")
     }
 
     buildTypes {
@@ -67,6 +68,10 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            buildConfigField("boolean", "USE_DISCORD_SYSTEM", "false")
+        }
+        debug {
+            buildConfigField("boolean", "USE_DISCORD_SYSTEM", "false")
         }
     }
     compileOptions {
@@ -75,6 +80,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     lint {
         abortOnError = false

--- a/app/src/main/java/com/test/testing/FeatureFlags.kt
+++ b/app/src/main/java/com/test/testing/FeatureFlags.kt
@@ -1,0 +1,40 @@
+package com.test.testing
+
+/**
+ * Feature flags for managing the development and staged rollout of the Discord + Backend system.
+ *
+ * ARCHITECTURE: TWO SEPARATE APPS WITHIN THE SAME CODEBASE
+ * - Discord System: Discord OAuth + MySku Backend API (aligns with iOS)
+ * - Firebase System: Firebase Auth + Firebase Realtime Database (current default)
+ *
+ * BuildConfig values (defined per build type in app/build.gradle.kts):
+ * - Debug: USE_DISCORD_SYSTEM = false (enable locally as needed)
+ * - Release: USE_DISCORD_SYSTEM = false (ship Firebase system only)
+ *
+ * Notes:
+ * - The feature flag must fully gate the Discord system. No UI or logic sharing across systems.
+ * - Keep default OFF across variants until the Discord flow is production-ready.
+ */
+object FeatureFlags {
+    /**
+     * Master toggle for enabling the Discord + Backend system.
+     *
+     * This is read from BuildConfig and should be set per build type in Gradle.
+     *
+     * TRUE (Discord System):
+     * - Auth: Discord OAuth 2.0 (PKCE)
+     * - Data: MySku Backend API
+     * - Features: Guilds, privacy, blocking
+     * - UI: Discord-specific navigation and screens
+     *
+     * FALSE (Firebase System):
+     * - Auth: Firebase (email/Google)
+     * - Data: Firebase Realtime Database
+     * - Features: Friends, location sharing
+     * - UI: Firebase-specific navigation and screens
+     *
+     * IMPORTANT: These are two separate apps within one codebase. Avoid UI mixing.
+     */
+    val USE_DISCORD_SYSTEM: Boolean
+        get() = BuildConfig.USE_DISCORD_SYSTEM
+}


### PR DESCRIPTION
Implement feature flag system to safely manage Discord OAuth
  rollout alongside existing Firebase system.

  - Add USE_DISCORD_SYSTEM BuildConfig field (default: false)
  - Create FeatureFlags object with comprehensive architecture
  documentation
  - Enable buildConfig feature in Gradle
  - Set up dual-system architecture foundation for zero-downtime
  migration

  This establishes the foundation for implementing Discord OAuth
  while maintaining Firebase system stability.