### PR TITLE
:wrench: (build) centralize OAuth config in BuildConfig

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,8 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("boolean", "USE_DISCORD_SYSTEM", "false")
         buildConfigField("String", "DISCORD_BACKEND_URL", "\"https://miniworld-new-staging.up.railway.app/\"")
+        buildConfigField("String", "DISCORD_CLIENT_ID", "\"1232840493696680038\"")
+        buildConfigField("String", "DISCORD_REDIRECT_URI", "\"mysku://redirect\"")
     }
 
     buildTypes {

--- a/app/src/test/java/com/test/testing/discord/auth/DiscordAuthCoordinatorTest.kt
+++ b/app/src/test/java/com/test/testing/discord/auth/DiscordAuthCoordinatorTest.kt
@@ -1,0 +1,25 @@
+package com.test.testing.discord.auth
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DiscordAuthCoordinatorTest {
+    @Test
+    fun buildAuthUri_includesRequiredParams() {
+        val uri = DiscordAuthCoordinator.buildAuthUri(codeChallenge = "abc", state = "xyz")
+        val combined =
+            listOf(
+                uri.getQueryParameter("client_id"),
+                uri.getQueryParameter("redirect_uri"),
+                uri.getQueryParameter("response_type"),
+                uri.getQueryParameter("scope"),
+                uri.getQueryParameter("code_challenge"),
+                uri.getQueryParameter("code_challenge_method"),
+                uri.getQueryParameter("state"),
+            ).joinToString("|")
+        assertEquals("1232840493696680038|mysku://redirect|code|identify guilds|abc|S256|xyz", combined)
+    }
+}


### PR DESCRIPTION
Move OAuth `client_id` and `redirect_uri` to BuildConfig to remove literals, enable environment overrides, and make the authorization URL builder test deterministic across build variants.