### PR TITLE
:recycle: (auth) extract DiscordAuthRepository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -127,6 +127,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.okhttp3.mockwebserver)
     testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/test/testing/discord/auth/DiscordAuthRepository.kt
+++ b/app/src/main/java/com/test/testing/discord/auth/DiscordAuthRepository.kt
@@ -1,0 +1,9 @@
+package com.test.testing.discord.auth
+
+interface DiscordAuthRepository {
+    suspend fun exchangeAndPersistToken(
+        code: String,
+        codeVerifier: String,
+        redirectUri: String,
+    ): Result<String>
+}

--- a/app/src/main/java/com/test/testing/discord/auth/DiscordAuthRepositoryImpl.kt
+++ b/app/src/main/java/com/test/testing/discord/auth/DiscordAuthRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package com.test.testing.discord.auth
+
+import android.content.Context
+import com.test.testing.discord.api.MySkuApiService
+import com.test.testing.discord.api.model.TokenRequest
+
+class DiscordAuthRepositoryImpl(
+    private val context: Context,
+    private val api: MySkuApiService,
+) : DiscordAuthRepository {
+    override suspend fun exchangeAndPersistToken(
+        code: String,
+        codeVerifier: String,
+        redirectUri: String,
+    ): Result<String> =
+        runCatching {
+            val resp = api.exchangeToken(TokenRequest(code, codeVerifier, redirectUri))
+            require(resp.accessToken.isNotEmpty())
+            TokenStore.put(context, resp.accessToken)
+            TokenStore.clearCodeVerifier(context)
+            TokenStore.clearState(context)
+            resp.accessToken
+        }
+}

--- a/app/src/test/java/com/test/testing/discord/auth/DiscordAuthRepositoryImplTest.kt
+++ b/app/src/test/java/com/test/testing/discord/auth/DiscordAuthRepositoryImplTest.kt
@@ -1,0 +1,68 @@
+package com.test.testing.discord.auth
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.gson.Gson
+import com.test.testing.discord.api.MySkuApiService
+import com.test.testing.discord.api.model.TokenResponse
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+@RunWith(RobolectricTestRunner::class)
+class DiscordAuthRepositoryImplTest {
+    private lateinit var server: MockWebServer
+    private lateinit var api: MySkuApiService
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        api =
+            Retrofit
+                .Builder()
+                .baseUrl(server.url("/"))
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+                .create(MySkuApiService::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `success persists token and clears verifier and state`() =
+        runBlocking {
+            server.enqueue(MockResponse().setResponseCode(200).setBody(Gson().toJson(TokenResponse(accessToken = "tok"))))
+            val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+            TokenStore.putCodeVerifier(context, "ver")
+            TokenStore.putState(context, "st")
+            val repo = DiscordAuthRepositoryImpl(context, api)
+            val result = repo.exchangeAndPersistToken("code", "ver", com.test.testing.BuildConfig.DISCORD_REDIRECT_URI)
+            assertEquals("tok", result.getOrNull())
+            assertEquals("tok", TokenStore.get(context))
+            assertTrue(TokenStore.getCodeVerifier(context).isNullOrEmpty())
+            assertTrue(TokenStore.getState(context).isNullOrEmpty())
+        }
+
+    @Test
+    fun `failure returns Result_failure and does not persist`() =
+        runBlocking {
+            server.enqueue(MockResponse().setResponseCode(500))
+            val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+            val repo = DiscordAuthRepositoryImpl(context, api)
+            val result = repo.exchangeAndPersistToken("code", "ver", com.test.testing.BuildConfig.DISCORD_REDIRECT_URI)
+            assertTrue(result.isFailure)
+            assertTrue(TokenStore.get(context).isNullOrEmpty())
+        }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ retrofit = "3.0.0"
 detekt = "1.23.8"
 mockwebserver = "5.1.0"
 robolectric = "4.15.1"
+androidxTestCore = "1.7.0"
 
 [libraries]
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
@@ -53,6 +54,7 @@ retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTestCore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Create `DiscordAuthRepository` and implementation to own token exchange and persistence; update callback Activity to delegate, enabling focused tests and future DI.