### PR TITLE
:sparkles: (guilds) add GuildRepository + count test

### DIFF
--- a/app/src/main/java/com/test/testing/discord/repo/GuildRepositoryImpl.kt
+++ b/app/src/main/java/com/test/testing/discord/repo/GuildRepositoryImpl.kt
@@ -1,0 +1,10 @@
+package com.test.testing.discord.repo
+
+import com.test.testing.discord.api.MySkuApiService
+import com.test.testing.discord.api.model.Guild
+
+class GuildRepositoryImpl(
+    private val api: MySkuApiService,
+) : GuildRepository {
+    override suspend fun getGuilds(): Result<List<Guild>> = runCatching { api.getGuilds() }
+}

--- a/app/src/test/java/com/test/testing/discord/repo/GuildRepositoryImplTest.kt
+++ b/app/src/test/java/com/test/testing/discord/repo/GuildRepositoryImplTest.kt
@@ -1,0 +1,46 @@
+package com.test.testing.discord.repo
+
+import com.google.gson.Gson
+import com.test.testing.discord.api.MySkuApiService
+import com.test.testing.discord.api.model.Guild
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+class GuildRepositoryImplTest {
+    private lateinit var server: MockWebServer
+    private lateinit var api: MySkuApiService
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        api =
+            Retrofit
+                .Builder()
+                .baseUrl(server.url("/"))
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+                .create(MySkuApiService::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `getGuilds returns list of expected size`() =
+        runBlocking {
+            val payload = listOf(Guild("1", "g1", null), Guild("2", "g2", null))
+            server.enqueue(MockResponse().setResponseCode(200).setBody(Gson().toJson(payload)))
+            val repo = GuildRepositoryImpl(api)
+            assertEquals(2, repo.getGuilds().getOrThrow().size)
+        }
+}


### PR DESCRIPTION
Implement `GuildRepositoryImpl.getGuilds()` delegating to
`MySkuApiService.getGuilds()`. Add MockWebServer test asserting list size. No UI
changes in this PR.

Closes MYS-34