### PR TITLE
:lock: (security) keystore token store + migration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -129,6 +129,7 @@ dependencies {
     implementation(libs.hilt.android)
     implementation(libs.androidx.hilt.navigation.compose)
     ksp(libs.hilt.compiler)
+    implementation(libs.security.crypto)
 
     testImplementation(libs.junit)
     testImplementation(libs.okhttp3.mockwebserver)

--- a/app/src/androidTest/java/com/test/testing/discord/auth/SecureTokenStoreInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/test/testing/discord/auth/SecureTokenStoreInstrumentedTest.kt
@@ -1,0 +1,28 @@
+package com.test.testing.discord.auth
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SecureTokenStoreInstrumentedTest {
+    @Test
+    fun writeThenRead_returnsSameToken() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        SecureTokenStore.put(context, "abc")
+        assertEquals("abc", SecureTokenStore.get(context))
+    }
+
+    @Test
+    fun migrateFromPlain_movesAndClears_plainStore() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        TokenStore.put(context, "plain")
+        SecureTokenStore.migrateFromPlain(context)
+        assertEquals("plain", SecureTokenStore.get(context))
+        assertTrue(TokenStore.get(context).isNullOrEmpty())
+    }
+}

--- a/app/src/main/java/com/test/testing/LocShareApp.kt
+++ b/app/src/main/java/com/test/testing/LocShareApp.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.util.Log
 import com.google.firebase.Firebase
 import com.google.firebase.initialize
+import com.test.testing.discord.auth.SecureTokenStore
 import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -30,6 +31,13 @@ class LocShareApp : Application() {
             Log.d(TAG, "Firebase initialized successfully")
         } catch (e: Exception) {
             Log.e(TAG, "Error initializing Firebase", e)
+        }
+
+        // Migrate any plain token to secure storage
+        try {
+            SecureTokenStore.migrateFromPlain(this)
+        } catch (e: Exception) {
+            Log.w(TAG, "Secure token migration failed", e)
         }
     }
 }

--- a/app/src/main/java/com/test/testing/discord/api/AuthInterceptor.kt
+++ b/app/src/main/java/com/test/testing/discord/api/AuthInterceptor.kt
@@ -1,18 +1,18 @@
 package com.test.testing.discord.api
 
 import android.content.Context
-import com.test.testing.discord.auth.TokenStore
+import com.test.testing.discord.auth.SecureTokenStore
 import okhttp3.Interceptor
 import okhttp3.Response
 
 /**
- * Adds Authorization header if a token exists (skeleton).
+ * Adds Authorization header if a token exists.
  */
 class AuthInterceptor(
     private val appContext: Context,
 ) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val token = TokenStore.get(appContext)
+        val token = SecureTokenStore.get(appContext)
         val request =
             if (!token.isNullOrEmpty()) {
                 chain

--- a/app/src/main/java/com/test/testing/discord/auth/SecureTokenStore.kt
+++ b/app/src/main/java/com/test/testing/discord/auth/SecureTokenStore.kt
@@ -1,0 +1,45 @@
+package com.test.testing.discord.auth
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+object SecureTokenStore {
+    private const val PREFS = "secure_discord_auth"
+    private const val KEY_TOKEN = "access_token"
+
+    private fun prefs(context: Context) =
+        EncryptedSharedPreferences.create(
+            context,
+            PREFS,
+            MasterKey.Builder(context).setKeyScheme(MasterKey.KeyScheme.AES256_GCM).build(),
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+
+    fun put(
+        context: Context,
+        token: String?,
+    ) {
+        val p = prefs(context)
+        if (token.isNullOrEmpty()) {
+            p.edit().remove(KEY_TOKEN).apply()
+        } else {
+            p.edit().putString(KEY_TOKEN, token).apply()
+        }
+    }
+
+    fun get(context: Context): String? = prefs(context).getString(KEY_TOKEN, null)
+
+    fun clear(context: Context) {
+        prefs(context).edit().remove(KEY_TOKEN).apply()
+    }
+
+    fun migrateFromPlain(context: Context) {
+        val plain = TokenStore.get(context)
+        if (!plain.isNullOrEmpty()) {
+            put(context, plain)
+            TokenStore.put(context, null)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ mockwebserver = "5.1.0"
 robolectric = "4.15.1"
 androidxTestCore = "1.7.0"
 coroutinesTest = "1.10.2"
+securityCrypto = "1.1.0"
 
 [libraries]
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
@@ -64,6 +65,7 @@ okhttp3-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTestCore" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesTest" }
+security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Introduce `SecureTokenStore` using AndroidX Security Crypto, migrate existing plain
tokens to encrypted storage, and switch `AuthInterceptor` to read from secure source.
Validate via instrumentation tests.

Closes MYS-26