### PR TITLE
:sparkles: (auth) add Demo login (uses /token with code=demo)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,7 @@ android {
         buildConfigField("String", "DISCORD_BACKEND_URL", "\"https://miniworld-new-staging.up.railway.app/\"")
         buildConfigField("String", "DISCORD_CLIENT_ID", "\"1232840493696680038\"")
         buildConfigField("String", "DISCORD_REDIRECT_URI", "\"mysku://redirect\"")
+        buildConfigField("boolean", "DISCORD_DEMO_MODE", "false")
     }
 
     buildTypes {
@@ -77,6 +78,7 @@ android {
         }
         debug {
             buildConfigField("boolean", "USE_DISCORD_SYSTEM", "false")
+            buildConfigField("boolean", "DISCORD_DEMO_MODE", "true")
         }
     }
     compileOptions {

--- a/app/src/main/java/com/test/testing/discord/auth/DiscordLoginActivity.kt
+++ b/app/src/main/java/com/test/testing/discord/auth/DiscordLoginActivity.kt
@@ -81,20 +81,22 @@ private fun DiscordLoginScreen(onContinue: () -> Unit) {
         }
 
         // Demo-mode quick path via backend /token (code = "demo")
-        Button(
-            onClick = {
-                val act = (context as androidx.activity.ComponentActivity)
-                act.lifecycleScope.launch {
-                    val api = ApiClient.create(act)
-                    val resp = api.exchangeToken(TokenRequest("demo", "demo", BuildConfig.DISCORD_REDIRECT_URI))
-                    SecureTokenStore.put(act, resp.accessToken)
-                    act.startActivity(Intent(act, DiscordMainActivity::class.java))
-                    act.finish()
-                }
-            },
-            modifier = Modifier.padding(top = 12.dp),
-        ) {
-            Text(text = "Try Demo (no account)")
+        if (BuildConfig.DISCORD_DEMO_MODE) {
+            Button(
+                onClick = {
+                    val act = (context as androidx.activity.ComponentActivity)
+                    act.lifecycleScope.launch {
+                        val api = ApiClient.create(act)
+                        val resp = api.exchangeToken(TokenRequest("demo", "demo", BuildConfig.DISCORD_REDIRECT_URI))
+                        SecureTokenStore.put(act, resp.accessToken)
+                        act.startActivity(Intent(act, DiscordMainActivity::class.java))
+                        act.finish()
+                    }
+                },
+                modifier = Modifier.padding(top = 12.dp),
+            ) {
+                Text(text = "Try Demo (no account)")
+            }
         }
 
         Button(


### PR DESCRIPTION
:sparkles: (auth) add Demo login (uses /token with code=demo)

Add a "Try Demo" button in `DiscordLoginActivity` (gated in next PR by a BuildConfig
flag) that exchanges `code = "demo"` via `/token`, stores the returned token, and
navigates to `DiscordMainActivity`.

:wrench: (build) add DISCORD_DEMO_MODE flag and get demo UI

Add `DISCORD_DEMO_MODE` BuildConfig (default false). Set true in `debug` buildType.
Show "Try Demo" button only when flag is true.